### PR TITLE
chore: speakeasy sdk regeneration - Generate Client SDKs for Wingspan benefits

### DIFF
--- a/previous-versions/benefits/README.md
+++ b/previous-versions/benefits/README.md
@@ -7,15 +7,15 @@
 </div>
 
 <!-- Start SDK Installation -->
-# SDK Installation
+## SDK Installation
 
-## NPM
+### NPM
 
 ```bash
 npm add openapi
 ```
 
-## Yarn
+### Yarn
 
 ```bash
 yarn add openapi
@@ -24,8 +24,6 @@ yarn add openapi
 
 ## SDK Example Usage
 <!-- Start SDK Example Usage -->
-
-
 ```typescript
 import { SDK } from "openapi";
 
@@ -45,9 +43,9 @@ import { SDK } from "openapi";
 <!-- End SDK Example Usage -->
 
 <!-- Start SDK Available Operations -->
-# Available Resources and Operations
+## Available Resources and Operations
 
-## [SDK](docs/sdks/sdk/README.md)
+### [SDK](docs/sdks/sdk/README.md)
 
 * [getBenefitsEnrollmentId](docs/sdks/sdk/README.md#getbenefitsenrollmentid) - Retrieve Enrollment Details for a Specific Member
 * [getBenefitsPlanEnrollment](docs/sdks/sdk/README.md#getbenefitsplanenrollment) - List all plan enrollments
@@ -57,8 +55,6 @@ import { SDK } from "openapi";
 <!-- End SDK Available Operations -->
 
 <!-- Start Dev Containers -->
-
-
 
 <!-- End Dev Containers -->
 

--- a/previous-versions/benefits/RELEASES.md
+++ b/previous-versions/benefits/RELEASES.md
@@ -9,3 +9,13 @@ Based on:
 - [typescript v0.1.0] previous-versions/benefits
 ### Releases
 - [NPM v0.1.0] https://www.npmjs.com/package/openapi/v/0.1.0 - previous-versions/benefits
+
+## 2023-10-17 19:40:53
+### Changes
+Based on:
+- OpenAPI Doc 1.0.0 https://docs.wingspan.app/openapi/6470f38d65c260000c025474
+- Speakeasy CLI 1.101.0 (2.161.0) https://github.com/speakeasy-api/speakeasy
+### Generated
+- [typescript v0.2.0] previous-versions/benefits
+### Releases
+- [NPM v0.2.0] https://www.npmjs.com/package/openapi/v/0.2.0 - previous-versions/benefits

--- a/previous-versions/benefits/gen.yaml
+++ b/previous-versions/benefits/gen.yaml
@@ -2,8 +2,8 @@ configVersion: 1.0.0
 management:
   docChecksum: e377727f5ba4f1205fcadb3246757bab
   docVersion: 1.0.0
-  speakeasyVersion: 1.100.2
-  generationVersion: 2.159.2
+  speakeasyVersion: 1.101.0
+  generationVersion: 2.161.0
 generation:
   sdkClassName: SDK
   singleTagPerOp: false
@@ -12,7 +12,7 @@ features:
     core: 2.90.4
     globalServerURLs: 2.82.0
 typescript:
-  version: 0.1.0
+  version: 0.2.0
   author: Speakeasy
   flattenGlobalSecurity: true
   maxMethodParams: 0

--- a/previous-versions/benefits/package-lock.json
+++ b/previous-versions/benefits/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openapi",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "openapi",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "axios": "^1.1.3",
         "class-transformer": "^0.5.1",

--- a/previous-versions/benefits/package.json
+++ b/previous-versions/benefits/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": "Speakeasy",
   "scripts": {
     "prepare": "tsc --build",

--- a/previous-versions/benefits/src/sdk/sdk.ts
+++ b/previous-versions/benefits/src/sdk/sdk.ts
@@ -53,9 +53,9 @@ export class SDKConfiguration {
     serverDefaults: any;
     language = "typescript";
     openapiDocVersion = "1.0.0";
-    sdkVersion = "0.1.0";
-    genVersion = "2.159.2";
-    userAgent = "speakeasy-sdk/typescript 0.1.0 2.159.2 1.0.0 openapi";
+    sdkVersion = "0.2.0";
+    genVersion = "2.161.0";
+    userAgent = "speakeasy-sdk/typescript 0.2.0 2.161.0 1.0.0 openapi";
     retryConfig?: utils.RetryConfig;
     public constructor(init?: Partial<SDKConfiguration>) {
         Object.assign(this, init);


### PR DESCRIPTION
# Generated by Speakeasy CLI
Based on:
- OpenAPI Doc 1.0.0 https://docs.wingspan.app/openapi/6470f38d65c260000c025474
- Speakeasy CLI 1.101.0 (2.161.0) https://github.com/speakeasy-api/speakeasy


## TYPESCRIPT CHANGELOG


