### PR TITLE
chore: speakeasy sdk regeneration - Generate Client SDKs for Wingspan benefits

### DIFF
--- a/benefits/README.md
+++ b/benefits/README.md
@@ -7,15 +7,15 @@
 </div>
 
 <!-- Start SDK Installation -->
-# SDK Installation
+## SDK Installation
 
-## NPM
+### NPM
 
 ```bash
 npm add @wingspanHQ/benefits
 ```
 
-## Yarn
+### Yarn
 
 ```bash
 yarn add @wingspanHQ/benefits
@@ -24,8 +24,6 @@ yarn add @wingspanHQ/benefits
 
 ## SDK Example Usage
 <!-- Start SDK Example Usage -->
-
-
 ```typescript
 import { Benefits } from "@wingspanHQ/benefits";
 
@@ -45,9 +43,9 @@ import { Benefits } from "@wingspanHQ/benefits";
 <!-- End SDK Example Usage -->
 
 <!-- Start SDK Available Operations -->
-# Available Resources and Operations
+## Available Resources and Operations
 
-## [Benefits SDK](docs/sdks/benefits/README.md)
+### [Benefits SDK](docs/sdks/benefits/README.md)
 
 * [getBenefitsEnrollmentId](docs/sdks/benefits/README.md#getbenefitsenrollmentid) - Retrieve Enrollment Details for a Specific Member
 * [getBenefitsPlanEnrollment](docs/sdks/benefits/README.md#getbenefitsplanenrollment) - List all plan enrollments
@@ -57,8 +55,6 @@ import { Benefits } from "@wingspanHQ/benefits";
 <!-- End SDK Available Operations -->
 
 <!-- Start Dev Containers -->
-
-
 
 <!-- End Dev Containers -->
 

--- a/benefits/RELEASES.md
+++ b/benefits/RELEASES.md
@@ -9,3 +9,13 @@ Based on:
 - [typescript v2.0.0] benefits
 ### Releases
 - [NPM v2.0.0] https://www.npmjs.com/package/@wingspanHQ/benefits/v/2.0.0 - benefits
+
+## 2023-10-18 14:22:23
+### Changes
+Based on:
+- OpenAPI Doc 1.0.0 https://docs.wingspan.app/openapi/6470f38d65c260000c025474
+- Speakeasy CLI 1.101.0 (2.161.0) https://github.com/speakeasy-api/speakeasy
+### Generated
+- [typescript v1.1.0] benefits
+### Releases
+- [NPM v1.1.0] https://www.npmjs.com/package/@wingspanHQ/benefits/v/1.1.0 - benefits

--- a/benefits/gen.yaml
+++ b/benefits/gen.yaml
@@ -13,7 +13,7 @@ features:
     core: 2.90.4
     globalServerURLs: 2.82.0
 typescript:
-  version: 1.0.0
+  version: 1.1.0
   author: Wingspan Networks, Inc.
   flattenGlobalSecurity: true
   maxMethodParams: "0"

--- a/benefits/package-lock.json
+++ b/benefits/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wingspanHQ/benefits",
-  "version": "2.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wingspanHQ/benefits",
-      "version": "2.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "axios": "^1.1.3",
         "class-transformer": "^0.5.1",

--- a/benefits/package.json
+++ b/benefits/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingspanHQ/benefits",
-  "version": "2.0.0",
+  "version": "1.1.0",
   "author": "Wingspan Networks, Inc.",
   "scripts": {
     "prepare": "tsc --build",

--- a/benefits/src/sdk/sdk.ts
+++ b/benefits/src/sdk/sdk.ts
@@ -53,9 +53,9 @@ export class SDKConfiguration {
     serverDefaults: any;
     language = "typescript";
     openapiDocVersion = "1.0.0";
-    sdkVersion = "2.0.0";
+    sdkVersion = "1.1.0";
     genVersion = "2.161.0";
-    userAgent = "speakeasy-sdk/typescript 2.0.0 2.161.0 1.0.0 @wingspanHQ/benefits";
+    userAgent = "speakeasy-sdk/typescript 1.1.0 2.161.0 1.0.0 @wingspanHQ/benefits";
     retryConfig?: utils.RetryConfig;
     public constructor(init?: Partial<SDKConfiguration>) {
         Object.assign(this, init);


### PR DESCRIPTION
# Generated by Speakeasy CLI
Based on:
- OpenAPI Doc 1.0.0 https://docs.wingspan.app/openapi/6470f38d65c260000c025474
- Speakeasy CLI 1.101.0 (2.161.0) https://github.com/speakeasy-api/speakeasy


## TYPESCRIPT CHANGELOG


