### PR TITLE
chore: speakeasy sdk regeneration - Generate Client SDKs for Wingspan benefits

### DIFF
--- a/benefits/README.md
+++ b/benefits/README.md
@@ -12,20 +12,20 @@
 ### NPM
 
 ```bash
-npm add @wingspanHQ/benefits
+npm add @wingspanhq/benefits
 ```
 
 ### Yarn
 
 ```bash
-yarn add @wingspanHQ/benefits
+yarn add @wingspanhq/benefits
 ```
 <!-- End SDK Installation -->
 
 ## SDK Example Usage
 <!-- Start SDK Example Usage -->
 ```typescript
-import { Benefits } from "@wingspanHQ/benefits";
+import { Benefits } from "@wingspanhq/benefits";
 
 (async () => {
     const sdk = new Benefits();

--- a/benefits/RELEASES.md
+++ b/benefits/RELEASES.md
@@ -19,3 +19,13 @@ Based on:
 - [typescript v1.1.0] benefits
 ### Releases
 - [NPM v1.1.0] https://www.npmjs.com/package/@wingspanHQ/benefits/v/1.1.0 - benefits
+
+## 2023-10-18 14:28:24
+### Changes
+Based on:
+- OpenAPI Doc 1.0.0 https://docs.wingspan.app/openapi/6470f38d65c260000c025474
+- Speakeasy CLI 1.101.0 (2.161.0) https://github.com/speakeasy-api/speakeasy
+### Generated
+- [typescript v1.2.0] benefits
+### Releases
+- [NPM v1.2.0] https://www.npmjs.com/package/@wingspanhq/benefits/v/1.2.0 - benefits

--- a/benefits/USAGE.md
+++ b/benefits/USAGE.md
@@ -2,7 +2,7 @@
 
 
 ```typescript
-import { Benefits } from "@wingspanHQ/benefits";
+import { Benefits } from "@wingspanhq/benefits";
 
 (async () => {
     const sdk = new Benefits();

--- a/benefits/docs/sdks/benefits/README.md
+++ b/benefits/docs/sdks/benefits/README.md
@@ -20,7 +20,7 @@ Fetches the enrollment status and details for a member identified by the provide
 ### Example Usage
 
 ```typescript
-import { Benefits } from "@wingspanHQ/benefits";
+import { Benefits } from "@wingspanhq/benefits";
 
 (async() => {
   const sdk = new Benefits();
@@ -55,7 +55,7 @@ List all plan enrollments
 ### Example Usage
 
 ```typescript
-import { Benefits } from "@wingspanHQ/benefits";
+import { Benefits } from "@wingspanhq/benefits";
 
 (async() => {
   const sdk = new Benefits();
@@ -87,7 +87,7 @@ Get a particular plan enrollment by ID
 ### Example Usage
 
 ```typescript
-import { Benefits } from "@wingspanHQ/benefits";
+import { Benefits } from "@wingspanhq/benefits";
 
 (async() => {
   const sdk = new Benefits();
@@ -122,7 +122,7 @@ Fetches the current status indicating whether the benefits service is enabled or
 ### Example Usage
 
 ```typescript
-import { Benefits } from "@wingspanHQ/benefits";
+import { Benefits } from "@wingspanhq/benefits";
 
 (async() => {
   const sdk = new Benefits();
@@ -154,7 +154,7 @@ Allows users to change the enablement status of a specified benefits service.
 ### Example Usage
 
 ```typescript
-import { Benefits } from "@wingspanHQ/benefits";
+import { Benefits } from "@wingspanhq/benefits";
 
 (async() => {
   const sdk = new Benefits();

--- a/benefits/gen.yaml
+++ b/benefits/gen.yaml
@@ -13,7 +13,7 @@ features:
     core: 2.90.4
     globalServerURLs: 2.82.0
 typescript:
-  version: 1.1.0
+  version: 1.2.0
   author: Wingspan Networks, Inc.
   flattenGlobalSecurity: true
   maxMethodParams: "0"

--- a/benefits/package-lock.json
+++ b/benefits/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@wingspanHQ/benefits",
-  "version": "1.1.0",
+  "name": "@wingspanhq/benefits",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@wingspanHQ/benefits",
-      "version": "1.1.0",
+      "name": "@wingspanhq/benefits",
+      "version": "1.2.0",
       "dependencies": {
         "axios": "^1.1.3",
         "class-transformer": "^0.5.1",

--- a/benefits/package.json
+++ b/benefits/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@wingspanHQ/benefits",
-  "version": "1.1.0",
+  "name": "@wingspanhq/benefits",
+  "version": "1.2.0",
   "author": "Wingspan Networks, Inc.",
   "scripts": {
     "prepare": "tsc --build",

--- a/benefits/src/sdk/sdk.ts
+++ b/benefits/src/sdk/sdk.ts
@@ -53,9 +53,9 @@ export class SDKConfiguration {
     serverDefaults: any;
     language = "typescript";
     openapiDocVersion = "1.0.0";
-    sdkVersion = "1.1.0";
+    sdkVersion = "1.2.0";
     genVersion = "2.161.0";
-    userAgent = "speakeasy-sdk/typescript 1.1.0 2.161.0 1.0.0 @wingspanHQ/benefits";
+    userAgent = "speakeasy-sdk/typescript 1.2.0 2.161.0 1.0.0 @wingspanhq/benefits";
     retryConfig?: utils.RetryConfig;
     public constructor(init?: Partial<SDKConfiguration>) {
         Object.assign(this, init);


### PR DESCRIPTION
# Generated by Speakeasy CLI
Based on:
- OpenAPI Doc 1.0.0 https://docs.wingspan.app/openapi/6470f38d65c260000c025474
- Speakeasy CLI 1.101.0 (2.161.0) https://github.com/speakeasy-api/speakeasy


## TYPESCRIPT CHANGELOG


