### PR TITLE
chore: speakeasy sdk regeneration - Generate Client SDKs for Wingspan benefits

### DIFF
--- a/benefits/RELEASES.md
+++ b/benefits/RELEASES.md
@@ -59,3 +59,13 @@ Based on:
 - [typescript v1.5.0] benefits
 ### Releases
 - [NPM v1.5.0] https://www.npmjs.com/package/@wingspan/benefits/v/1.5.0 - benefits
+
+## 2023-10-20 20:12:46
+### Changes
+Based on:
+- OpenAPI Doc 1.0.0 https://docs.wingspan.app/openapi/6470f38d65c260000c025474
+- Speakeasy CLI 1.102.1 (2.166.0) https://github.com/speakeasy-api/speakeasy
+### Generated
+- [typescript v1.6.0] benefits
+### Releases
+- [NPM v1.6.0] https://www.npmjs.com/package/@wingspan/benefits/v/1.6.0 - benefits

--- a/benefits/gen.yaml
+++ b/benefits/gen.yaml
@@ -2,7 +2,7 @@ configVersion: 1.0.0
 management:
   docChecksum: e377727f5ba4f1205fcadb3246757bab
   docVersion: 1.0.0
-  speakeasyVersion: 1.102.0
+  speakeasyVersion: 1.102.1
   generationVersion: 2.166.0
 generation:
   repoURL: https://github.com/wingspanHQ/client-sdk-typescript.git
@@ -14,7 +14,7 @@ features:
     core: 2.92.4
     globalServerURLs: 2.82.0
 typescript:
-  version: 1.5.0
+  version: 1.6.0
   author: Wingspan Networks, Inc.
   flattenGlobalSecurity: true
   installationURL: https://gitpkg.now.sh/wingspanHQ/client-sdk-typescript/benefits

--- a/benefits/package-lock.json
+++ b/benefits/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wingspan/benefits",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wingspan/benefits",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "dependencies": {
         "axios": "^1.1.3",
         "class-transformer": "^0.5.1",

--- a/benefits/package.json
+++ b/benefits/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingspan/benefits",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "author": "Wingspan Networks, Inc.",
   "scripts": {
     "prepare": "tsc --build",

--- a/benefits/src/sdk/sdk.ts
+++ b/benefits/src/sdk/sdk.ts
@@ -53,9 +53,9 @@ export class SDKConfiguration {
     serverDefaults: any;
     language = "typescript";
     openapiDocVersion = "1.0.0";
-    sdkVersion = "1.5.0";
+    sdkVersion = "1.6.0";
     genVersion = "2.166.0";
-    userAgent = "speakeasy-sdk/typescript 1.5.0 2.166.0 1.0.0 @wingspan/benefits";
+    userAgent = "speakeasy-sdk/typescript 1.6.0 2.166.0 1.0.0 @wingspan/benefits";
     retryConfig?: utils.RetryConfig;
     public constructor(init?: Partial<SDKConfiguration>) {
         Object.assign(this, init);


### PR DESCRIPTION
# Generated by Speakeasy CLI
Based on:
- OpenAPI Doc 1.0.0 https://docs.wingspan.app/openapi/6470f38d65c260000c025474
- Speakeasy CLI 1.102.1 (2.166.0) https://github.com/speakeasy-api/speakeasy


## TYPESCRIPT CHANGELOG


