### PR TITLE
chore: speakeasy sdk regeneration - Generate Client SDKs for Wingspan integrations

### DIFF
--- a/integrations/README.md
+++ b/integrations/README.md
@@ -7,15 +7,15 @@
 </div>
 
 <!-- Start SDK Installation -->
-# SDK Installation
+## SDK Installation
 
-## NPM
+### NPM
 
 ```bash
 npm add @wingspan/integrations
 ```
 
-## Yarn
+### Yarn
 
 ```bash
 yarn add @wingspan/integrations
@@ -24,8 +24,6 @@ yarn add @wingspan/integrations
 
 ## SDK Example Usage
 <!-- Start SDK Example Usage -->
-
-
 ```typescript
 import { Integrations } from "@wingspan/integrations";
 
@@ -45,9 +43,9 @@ import { Integrations } from "@wingspan/integrations";
 <!-- End SDK Example Usage -->
 
 <!-- Start SDK Available Operations -->
-# Available Resources and Operations
+## Available Resources and Operations
 
-## [Integrations SDK](docs/sdks/integrations/README.md)
+### [Integrations SDK](docs/sdks/integrations/README.md)
 
 * [deleteIntegrationsQuickbooksAccountAssetId](docs/sdks/integrations/README.md#deleteintegrationsquickbooksaccountassetid) - Delete Quickbooks Account details
 * [deleteIntegrationsQuickbooksAccountEquityId](docs/sdks/integrations/README.md#deleteintegrationsquickbooksaccountequityid) - Delete Quickbooks Account details
@@ -106,8 +104,6 @@ import { Integrations } from "@wingspan/integrations";
 <!-- End SDK Available Operations -->
 
 <!-- Start Dev Containers -->
-
-
 
 <!-- End Dev Containers -->
 

--- a/integrations/RELEASES.md
+++ b/integrations/RELEASES.md
@@ -9,3 +9,13 @@ Based on:
 - [typescript v2.0.0] integrations
 ### Releases
 - [NPM v2.0.0] https://www.npmjs.com/package/@wingspan/integrations/v/2.0.0 - integrations
+
+## 2023-10-20 20:25:20
+### Changes
+Based on:
+- OpenAPI Doc 1.0.0 https://docs.wingspan.app/openapi/650da31d2b30f6000ce71dd7
+- Speakeasy CLI 1.103.0 (2.168.0) https://github.com/speakeasy-api/speakeasy
+### Generated
+- [typescript v2.1.0] integrations
+### Releases
+- [NPM v2.1.0] https://www.npmjs.com/package/@wingspan/integrations/v/2.1.0 - integrations

--- a/integrations/docs/sdks/integrations/README.md
+++ b/integrations/docs/sdks/integrations/README.md
@@ -1520,7 +1520,7 @@ import { Integrations } from "@wingspan/integrations";
   const res = await sdk.integrations.patchIntegrationsWebhooksPreferenceId({
     webhooksPreferenceUpdateRequest: {
       subscribedEvents: [
-        "alarm",
+        "string",
       ],
     },
     id: "<ID>",
@@ -1790,7 +1790,7 @@ import { Integrations } from "@wingspan/integrations";
 
   const res = await sdk.integrations.postIntegrationsQuickbooksService({
     defaults: {},
-    redirectUrl: "Rock",
+    redirectUrl: "string",
   });
 
   if (res.statusCode == 200) {
@@ -1894,11 +1894,11 @@ import { Integrations } from "@wingspan/integrations";
   const sdk = new Integrations();
 
   const res = await sdk.integrations.postIntegrationsWebhooksPreference({
-    sharedSecret: "Soap",
+    sharedSecret: "string",
     subscribedEvents: [
-      "et",
+      "string",
     ],
-    url: "http://concrete-acknowledgment.org",
+    url: "http://corny-registry.name",
   });
 
   if (res.statusCode == 200) {

--- a/integrations/gen.yaml
+++ b/integrations/gen.yaml
@@ -2,8 +2,8 @@ configVersion: 1.0.0
 management:
   docChecksum: c2d453cc77acccdfaae0accd2b0854b2
   docVersion: 1.0.0
-  speakeasyVersion: 1.102.0
-  generationVersion: 2.166.0
+  speakeasyVersion: 1.103.0
+  generationVersion: 2.168.0
 generation:
   repoURL: https://github.com/wingspanHQ/client-sdk-typescript.git
   sdkClassName: integrations
@@ -14,7 +14,7 @@ features:
     core: 2.92.4
     globalServerURLs: 2.82.0
 typescript:
-  version: 2.0.0
+  version: 2.1.0
   author: Wingspan Networks, Inc.
   flattenGlobalSecurity: true
   installationURL: https://gitpkg.now.sh/wingspanHQ/client-sdk-typescript/integrations

--- a/integrations/package-lock.json
+++ b/integrations/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wingspan/integrations",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wingspan/integrations",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "dependencies": {
         "axios": "^1.1.3",
         "class-transformer": "^0.5.1",

--- a/integrations/package.json
+++ b/integrations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingspan/integrations",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": "Wingspan Networks, Inc.",
   "scripts": {
     "prepare": "tsc --build",

--- a/integrations/src/sdk/sdk.ts
+++ b/integrations/src/sdk/sdk.ts
@@ -53,9 +53,9 @@ export class SDKConfiguration {
     serverDefaults: any;
     language = "typescript";
     openapiDocVersion = "1.0.0";
-    sdkVersion = "2.0.0";
-    genVersion = "2.166.0";
-    userAgent = "speakeasy-sdk/typescript 2.0.0 2.166.0 1.0.0 @wingspan/integrations";
+    sdkVersion = "2.1.0";
+    genVersion = "2.168.0";
+    userAgent = "speakeasy-sdk/typescript 2.1.0 2.168.0 1.0.0 @wingspan/integrations";
     retryConfig?: utils.RetryConfig;
     public constructor(init?: Partial<SDKConfiguration>) {
         Object.assign(this, init);


### PR DESCRIPTION
# Generated by Speakeasy CLI
Based on:
- OpenAPI Doc 1.0.0 https://docs.wingspan.app/openapi/650da31d2b30f6000ce71dd7
- Speakeasy CLI 1.103.0 (2.168.0) https://github.com/speakeasy-api/speakeasy


## TYPESCRIPT CHANGELOG


