### PR TITLE
chore: speakeasy sdk regeneration - Generate Client SDKs for Wingspan integrations

### DIFF
--- a/integrations/README.md
+++ b/integrations/README.md
@@ -107,6 +107,103 @@ import { Integrations } from "@wingspan/integrations";
 
 <!-- End Dev Containers -->
 
+
+
+<!-- Start Error Handling -->
+# Error Handling
+
+Handling errors in your SDK should largely match your expectations.  All operations return a response object or throw an error.  If Error objects are specified in your OpenAPI Spec, the SDK will throw the appropriate Error type.
+
+
+<!-- End Error Handling -->
+
+
+
+<!-- Start Server Selection -->
+# Server Selection
+
+## Select Server by Index
+
+You can override the default server globally by passing a server index to the `serverIdx: number` optional parameter when initializing the SDK client instance. The selected server will then be used as the default on the operations that use it. This table lists the indexes associated with the available servers:
+
+| # | Server | Variables |
+| - | ------ | --------- |
+| 0 | `https://api.wingspan.app` | None |
+| 1 | `https://stagingapi.wingspan.app` | None |
+
+For example:
+
+
+```typescript
+import { Integrations } from "@wingspan/integrations";
+
+(async () => {
+    const sdk = new Integrations({
+        serverIdx: 1,
+    });
+
+    const res = await sdk.integrations.deleteIntegrationsQuickbooksAccountAssetId({
+        id: "<ID>",
+    });
+
+    if (res.statusCode == 200) {
+        // handle response
+    }
+})();
+
+```
+
+
+## Override Server URL Per-Client
+
+The default server can also be overridden globally by passing a URL to the `serverURL: str` optional parameter when initializing the SDK client instance. For example:
+
+
+```typescript
+import { Integrations } from "@wingspan/integrations";
+
+(async () => {
+    const sdk = new Integrations({
+        serverURL: "https://api.wingspan.app",
+    });
+
+    const res = await sdk.integrations.deleteIntegrationsQuickbooksAccountAssetId({
+        id: "<ID>",
+    });
+
+    if (res.statusCode == 200) {
+        // handle response
+    }
+})();
+
+```
+<!-- End Server Selection -->
+
+
+
+<!-- Start Custom HTTP Client -->
+# Custom HTTP Client
+
+The Typescript SDK makes API calls using the (axios)[https://axios-http.com/docs/intro] HTTP library.  In order to provide a convenient way to configure timeouts, cookies, proxies, custom headers, and other low-level configuration, you can initialize the SDK client with a custom `AxiosInstance` object.
+
+
+For example, you could specify a header for every request that your sdk makes as follows:
+
+```typescript
+from @wingspan/integrations import Integrations;
+import axios;
+
+const httpClient = axios.create({
+    headers: {'x-custom-header': 'someValue'}
+})
+
+
+const sdk = new Integrations({defaultClient: httpClient});
+```
+
+
+<!-- End Custom HTTP Client -->
+
 <!-- Placeholder for Future Speakeasy SDK Sections -->
 
 # Development

--- a/integrations/RELEASES.md
+++ b/integrations/RELEASES.md
@@ -29,3 +29,13 @@ Based on:
 - [typescript v2.2.0] integrations
 ### Releases
 - [NPM v2.2.0] https://www.npmjs.com/package/@wingspan/integrations/v/2.2.0 - integrations
+
+## 2023-10-30 01:26:34
+### Changes
+Based on:
+- OpenAPI Doc 1.0.0 https://docs.wingspan.app/openapi/650da31d2b30f6000ce71dd7
+- Speakeasy CLI 1.109.0 (2.173.0) https://github.com/speakeasy-api/speakeasy
+### Generated
+- [typescript v2.3.0] integrations
+### Releases
+- [NPM v2.3.0] https://www.npmjs.com/package/@wingspan/integrations/v/2.3.0 - integrations

--- a/integrations/RELEASES.md
+++ b/integrations/RELEASES.md
@@ -19,3 +19,13 @@ Based on:
 - [typescript v2.1.0] integrations
 ### Releases
 - [NPM v2.1.0] https://www.npmjs.com/package/@wingspan/integrations/v/2.1.0 - integrations
+
+## 2023-10-23 01:26:42
+### Changes
+Based on:
+- OpenAPI Doc 1.0.0 https://docs.wingspan.app/openapi/650da31d2b30f6000ce71dd7
+- Speakeasy CLI 1.104.0 (2.169.0) https://github.com/speakeasy-api/speakeasy
+### Generated
+- [typescript v2.2.0] integrations
+### Releases
+- [NPM v2.2.0] https://www.npmjs.com/package/@wingspan/integrations/v/2.2.0 - integrations

--- a/integrations/docs/sdks/integrations/README.md
+++ b/integrations/docs/sdks/integrations/README.md
@@ -78,6 +78,7 @@ import { Integrations } from "@wingspan/integrations";
     id: "<ID>",
   });
 
+
   if (res.statusCode == 200) {
     // handle response
   }
@@ -112,6 +113,7 @@ import { Integrations } from "@wingspan/integrations";
   const res = await sdk.integrations.deleteIntegrationsQuickbooksAccountEquityId({
     id: "<ID>",
   });
+
 
   if (res.statusCode == 200) {
     // handle response
@@ -148,6 +150,7 @@ import { Integrations } from "@wingspan/integrations";
     id: "<ID>",
   });
 
+
   if (res.statusCode == 200) {
     // handle response
   }
@@ -182,6 +185,7 @@ import { Integrations } from "@wingspan/integrations";
   const res = await sdk.integrations.deleteIntegrationsQuickbooksAccountLiabilityId({
     id: "<ID>",
   });
+
 
   if (res.statusCode == 200) {
     // handle response
@@ -218,6 +222,7 @@ import { Integrations } from "@wingspan/integrations";
     id: "<ID>",
   });
 
+
   if (res.statusCode == 200) {
     // handle response
   }
@@ -252,6 +257,7 @@ import { Integrations } from "@wingspan/integrations";
   const res = await sdk.integrations.deleteIntegrationsQuickbooksCustomerId({
     id: "<ID>",
   });
+
 
   if (res.statusCode == 200) {
     // handle response
@@ -288,6 +294,7 @@ import { Integrations } from "@wingspan/integrations";
     id: "<ID>",
   });
 
+
   if (res.statusCode == 200) {
     // handle response
   }
@@ -320,6 +327,7 @@ import { Integrations } from "@wingspan/integrations";
   const sdk = new Integrations();
 
   const res = await sdk.integrations.deleteIntegrationsQuickbooksService();
+
 
   if (res.statusCode == 200) {
     // handle response
@@ -354,6 +362,7 @@ import { Integrations } from "@wingspan/integrations";
   const res = await sdk.integrations.deleteIntegrationsQuickbooksVendorId({
     id: "<ID>",
   });
+
 
   if (res.statusCode == 200) {
     // handle response
@@ -390,6 +399,7 @@ import { Integrations } from "@wingspan/integrations";
     id: "<ID>",
   });
 
+
   if (res.statusCode == 200) {
     // handle response
   }
@@ -422,6 +432,7 @@ import { Integrations } from "@wingspan/integrations";
   const sdk = new Integrations();
 
   const res = await sdk.integrations.getIntegrationsQuickbooksAccountAsset();
+
 
   if (res.statusCode == 200) {
     // handle response
@@ -457,6 +468,7 @@ import { Integrations } from "@wingspan/integrations";
     id: "<ID>",
   });
 
+
   if (res.statusCode == 200) {
     // handle response
   }
@@ -489,6 +501,7 @@ import { Integrations } from "@wingspan/integrations";
   const sdk = new Integrations();
 
   const res = await sdk.integrations.getIntegrationsQuickbooksAccountEquity();
+
 
   if (res.statusCode == 200) {
     // handle response
@@ -524,6 +537,7 @@ import { Integrations } from "@wingspan/integrations";
     id: "<ID>",
   });
 
+
   if (res.statusCode == 200) {
     // handle response
   }
@@ -556,6 +570,7 @@ import { Integrations } from "@wingspan/integrations";
   const sdk = new Integrations();
 
   const res = await sdk.integrations.getIntegrationsQuickbooksAccountExpense();
+
 
   if (res.statusCode == 200) {
     // handle response
@@ -591,6 +606,7 @@ import { Integrations } from "@wingspan/integrations";
     id: "<ID>",
   });
 
+
   if (res.statusCode == 200) {
     // handle response
   }
@@ -623,6 +639,7 @@ import { Integrations } from "@wingspan/integrations";
   const sdk = new Integrations();
 
   const res = await sdk.integrations.getIntegrationsQuickbooksAccountLiability();
+
 
   if (res.statusCode == 200) {
     // handle response
@@ -658,6 +675,7 @@ import { Integrations } from "@wingspan/integrations";
     id: "<ID>",
   });
 
+
   if (res.statusCode == 200) {
     // handle response
   }
@@ -690,6 +708,7 @@ import { Integrations } from "@wingspan/integrations";
   const sdk = new Integrations();
 
   const res = await sdk.integrations.getIntegrationsQuickbooksAccountRevenue();
+
 
   if (res.statusCode == 200) {
     // handle response
@@ -725,6 +744,7 @@ import { Integrations } from "@wingspan/integrations";
     id: "<ID>",
   });
 
+
   if (res.statusCode == 200) {
     // handle response
   }
@@ -757,6 +777,7 @@ import { Integrations } from "@wingspan/integrations";
   const sdk = new Integrations();
 
   const res = await sdk.integrations.getIntegrationsQuickbooksCustomer();
+
 
   if (res.statusCode == 200) {
     // handle response
@@ -792,6 +813,7 @@ import { Integrations } from "@wingspan/integrations";
     id: "<ID>",
   });
 
+
   if (res.statusCode == 200) {
     // handle response
   }
@@ -824,6 +846,7 @@ import { Integrations } from "@wingspan/integrations";
   const sdk = new Integrations();
 
   const res = await sdk.integrations.getIntegrationsQuickbooksItem();
+
 
   if (res.statusCode == 200) {
     // handle response
@@ -859,6 +882,7 @@ import { Integrations } from "@wingspan/integrations";
     id: "<ID>",
   });
 
+
   if (res.statusCode == 200) {
     // handle response
   }
@@ -892,6 +916,7 @@ import { Integrations } from "@wingspan/integrations";
 
   const res = await sdk.integrations.getIntegrationsQuickbooksService();
 
+
   if (res.statusCode == 200) {
     // handle response
   }
@@ -923,6 +948,7 @@ import { Integrations } from "@wingspan/integrations";
   const sdk = new Integrations();
 
   const res = await sdk.integrations.getIntegrationsQuickbooksServiceSyncActivity();
+
 
   if (res.statusCode == 200) {
     // handle response
@@ -958,6 +984,7 @@ import { Integrations } from "@wingspan/integrations";
     id: "<ID>",
   });
 
+
   if (res.statusCode == 200) {
     // handle response
   }
@@ -990,6 +1017,7 @@ import { Integrations } from "@wingspan/integrations";
   const sdk = new Integrations();
 
   const res = await sdk.integrations.getIntegrationsQuickbooksVendor();
+
 
   if (res.statusCode == 200) {
     // handle response
@@ -1025,6 +1053,7 @@ import { Integrations } from "@wingspan/integrations";
     id: "<ID>",
   });
 
+
   if (res.statusCode == 200) {
     // handle response
   }
@@ -1058,6 +1087,7 @@ import { Integrations } from "@wingspan/integrations";
 
   const res = await sdk.integrations.getIntegrationsWebhooksEventnames();
 
+
   if (res.statusCode == 200) {
     // handle response
   }
@@ -1089,6 +1119,7 @@ import { Integrations } from "@wingspan/integrations";
   const sdk = new Integrations();
 
   const res = await sdk.integrations.getIntegrationsWebhooksPreference();
+
 
   if (res.statusCode == 200) {
     // handle response
@@ -1123,6 +1154,7 @@ import { Integrations } from "@wingspan/integrations";
   const res = await sdk.integrations.getIntegrationsWebhooksPreferenceId({
     id: "<ID>",
   });
+
 
   if (res.statusCode == 200) {
     // handle response
@@ -1160,6 +1192,7 @@ import { Integrations } from "@wingspan/integrations";
     id: "<ID>",
   });
 
+
   if (res.statusCode == 200) {
     // handle response
   }
@@ -1195,6 +1228,7 @@ import { Integrations } from "@wingspan/integrations";
     integrationAccountCreateRequest: {},
     id: "<ID>",
   });
+
 
   if (res.statusCode == 200) {
     // handle response
@@ -1232,6 +1266,7 @@ import { Integrations } from "@wingspan/integrations";
     id: "<ID>",
   });
 
+
   if (res.statusCode == 200) {
     // handle response
   }
@@ -1267,6 +1302,7 @@ import { Integrations } from "@wingspan/integrations";
     integrationAccountCreateRequest: {},
     id: "<ID>",
   });
+
 
   if (res.statusCode == 200) {
     // handle response
@@ -1304,6 +1340,7 @@ import { Integrations } from "@wingspan/integrations";
     id: "<ID>",
   });
 
+
   if (res.statusCode == 200) {
     // handle response
   }
@@ -1339,6 +1376,7 @@ import { Integrations } from "@wingspan/integrations";
     integrationCustomerCreateRequest: {},
     id: "<ID>",
   });
+
 
   if (res.statusCode == 200) {
     // handle response
@@ -1376,6 +1414,7 @@ import { Integrations } from "@wingspan/integrations";
     id: "<ID>",
   });
 
+
   if (res.statusCode == 200) {
     // handle response
   }
@@ -1411,6 +1450,7 @@ import { IntegrationsQuickbooksUpdateRequestSyncStatus } from "@wingspan/integra
   const res = await sdk.integrations.patchIntegrationsQuickbooksService({
     defaults: {},
   });
+
 
   if (res.statusCode == 200) {
     // handle response
@@ -1450,6 +1490,7 @@ import { Integrations } from "@wingspan/integrations";
     id: "<ID>",
   });
 
+
   if (res.statusCode == 200) {
     // handle response
   }
@@ -1485,6 +1526,7 @@ import { Integrations } from "@wingspan/integrations";
     integrationVendorCreateRequest: {},
     id: "<ID>",
   });
+
 
   if (res.statusCode == 200) {
     // handle response
@@ -1526,6 +1568,7 @@ import { Integrations } from "@wingspan/integrations";
     id: "<ID>",
   });
 
+
   if (res.statusCode == 200) {
     // handle response
   }
@@ -1558,6 +1601,7 @@ import { Integrations } from "@wingspan/integrations";
   const sdk = new Integrations();
 
   const res = await sdk.integrations.postIntegrationsQuickbooksAccountAsset({});
+
 
   if (res.statusCode == 200) {
     // handle response
@@ -1592,6 +1636,7 @@ import { Integrations } from "@wingspan/integrations";
 
   const res = await sdk.integrations.postIntegrationsQuickbooksAccountEquity({});
 
+
   if (res.statusCode == 200) {
     // handle response
   }
@@ -1624,6 +1669,7 @@ import { Integrations } from "@wingspan/integrations";
   const sdk = new Integrations();
 
   const res = await sdk.integrations.postIntegrationsQuickbooksAccountExpense({});
+
 
   if (res.statusCode == 200) {
     // handle response
@@ -1658,6 +1704,7 @@ import { Integrations } from "@wingspan/integrations";
 
   const res = await sdk.integrations.postIntegrationsQuickbooksAccountLiability({});
 
+
   if (res.statusCode == 200) {
     // handle response
   }
@@ -1690,6 +1737,7 @@ import { Integrations } from "@wingspan/integrations";
   const sdk = new Integrations();
 
   const res = await sdk.integrations.postIntegrationsQuickbooksAccountRevenue({});
+
 
   if (res.statusCode == 200) {
     // handle response
@@ -1724,6 +1772,7 @@ import { Integrations } from "@wingspan/integrations";
 
   const res = await sdk.integrations.postIntegrationsQuickbooksCustomer({});
 
+
   if (res.statusCode == 200) {
     // handle response
   }
@@ -1756,6 +1805,7 @@ import { Integrations } from "@wingspan/integrations";
   const sdk = new Integrations();
 
   const res = await sdk.integrations.postIntegrationsQuickbooksItem({});
+
 
   if (res.statusCode == 200) {
     // handle response
@@ -1793,6 +1843,7 @@ import { Integrations } from "@wingspan/integrations";
     redirectUrl: "string",
   });
 
+
   if (res.statusCode == 200) {
     // handle response
   }
@@ -1829,6 +1880,7 @@ import { Integrations } from "@wingspan/integrations";
     id: "<ID>",
   });
 
+
   if (res.statusCode == 200) {
     // handle response
   }
@@ -1861,6 +1913,7 @@ import { Integrations } from "@wingspan/integrations";
   const sdk = new Integrations();
 
   const res = await sdk.integrations.postIntegrationsQuickbooksVendor({});
+
 
   if (res.statusCode == 200) {
     // handle response
@@ -1900,6 +1953,7 @@ import { Integrations } from "@wingspan/integrations";
     ],
     url: "http://corny-registry.name",
   });
+
 
   if (res.statusCode == 200) {
     // handle response

--- a/integrations/gen.yaml
+++ b/integrations/gen.yaml
@@ -2,8 +2,8 @@ configVersion: 1.0.0
 management:
   docChecksum: c2d453cc77acccdfaae0accd2b0854b2
   docVersion: 1.0.0
-  speakeasyVersion: 1.103.0
-  generationVersion: 2.168.0
+  speakeasyVersion: 1.104.0
+  generationVersion: 2.169.0
 generation:
   repoURL: https://github.com/wingspanHQ/client-sdk-typescript.git
   sdkClassName: integrations
@@ -11,10 +11,10 @@ generation:
   telemetryEnabled: false
 features:
   typescript:
-    core: 2.92.4
+    core: 2.93.0
     globalServerURLs: 2.82.0
 typescript:
-  version: 2.1.0
+  version: 2.2.0
   author: Wingspan Networks, Inc.
   flattenGlobalSecurity: true
   installationURL: https://gitpkg.now.sh/wingspanHQ/client-sdk-typescript/integrations

--- a/integrations/gen.yaml
+++ b/integrations/gen.yaml
@@ -2,8 +2,8 @@ configVersion: 1.0.0
 management:
   docChecksum: c2d453cc77acccdfaae0accd2b0854b2
   docVersion: 1.0.0
-  speakeasyVersion: 1.104.0
-  generationVersion: 2.169.0
+  speakeasyVersion: 1.109.0
+  generationVersion: 2.173.0
 generation:
   repoURL: https://github.com/wingspanHQ/client-sdk-typescript.git
   sdkClassName: integrations
@@ -11,10 +11,10 @@ generation:
   telemetryEnabled: false
 features:
   typescript:
-    core: 2.93.0
+    core: 2.94.0
     globalServerURLs: 2.82.0
 typescript:
-  version: 2.2.0
+  version: 2.3.0
   author: Wingspan Networks, Inc.
   flattenGlobalSecurity: true
   installationURL: https://gitpkg.now.sh/wingspanHQ/client-sdk-typescript/integrations

--- a/integrations/package-lock.json
+++ b/integrations/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wingspan/integrations",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wingspan/integrations",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "dependencies": {
         "axios": "^1.1.3",
         "class-transformer": "^0.5.1",

--- a/integrations/package-lock.json
+++ b/integrations/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wingspan/integrations",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wingspan/integrations",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "dependencies": {
         "axios": "^1.1.3",
         "class-transformer": "^0.5.1",

--- a/integrations/package.json
+++ b/integrations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingspan/integrations",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "author": "Wingspan Networks, Inc.",
   "scripts": {
     "prepare": "tsc --build",

--- a/integrations/package.json
+++ b/integrations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingspan/integrations",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "author": "Wingspan Networks, Inc.",
   "scripts": {
     "prepare": "tsc --build",

--- a/integrations/src/internal/utils/security.ts
+++ b/integrations/src/internal/utils/security.ts
@@ -179,7 +179,7 @@ function parseSecuritySchemeValue(
       properties.headers[securityDecorator.Name] = value;
       break;
     case "oauth2":
-      properties.headers[securityDecorator.Name] = value;
+      properties.headers[securityDecorator.Name] = value.toLowerCase().startsWith("bearer ") ? value : `Bearer ${value}`;
       break;
     case "http":
       switch (schemeDecorator.SubType) {

--- a/integrations/src/sdk/sdk.ts
+++ b/integrations/src/sdk/sdk.ts
@@ -53,9 +53,9 @@ export class SDKConfiguration {
     serverDefaults: any;
     language = "typescript";
     openapiDocVersion = "1.0.0";
-    sdkVersion = "2.2.0";
-    genVersion = "2.169.0";
-    userAgent = "speakeasy-sdk/typescript 2.2.0 2.169.0 1.0.0 @wingspan/integrations";
+    sdkVersion = "2.3.0";
+    genVersion = "2.173.0";
+    userAgent = "speakeasy-sdk/typescript 2.3.0 2.173.0 1.0.0 @wingspan/integrations";
     retryConfig?: utils.RetryConfig;
     public constructor(init?: Partial<SDKConfiguration>) {
         Object.assign(this, init);

--- a/integrations/src/sdk/sdk.ts
+++ b/integrations/src/sdk/sdk.ts
@@ -53,9 +53,9 @@ export class SDKConfiguration {
     serverDefaults: any;
     language = "typescript";
     openapiDocVersion = "1.0.0";
-    sdkVersion = "2.1.0";
-    genVersion = "2.168.0";
-    userAgent = "speakeasy-sdk/typescript 2.1.0 2.168.0 1.0.0 @wingspan/integrations";
+    sdkVersion = "2.2.0";
+    genVersion = "2.169.0";
+    userAgent = "speakeasy-sdk/typescript 2.2.0 2.169.0 1.0.0 @wingspan/integrations";
     retryConfig?: utils.RetryConfig;
     public constructor(init?: Partial<SDKConfiguration>) {
         Object.assign(this, init);


### PR DESCRIPTION
# Generated by Speakeasy CLI
Based on:
- OpenAPI Doc 1.0.0 https://docs.wingspan.app/openapi/650da31d2b30f6000ce71dd7
- Speakeasy CLI 1.109.0 (2.173.0) https://github.com/speakeasy-api/speakeasy


## TYPESCRIPT CHANGELOG

## core: 2.94.0 - 2023-10-24
### :bee: New Features
- oauth defaults to bearer usage *(commit by [@ryan-timothy-albert](https://github.com/ryan-timothy-albert))*


