### PR TITLE
chore: speakeasy sdk regeneration - Generate Client SDKs for Wingspan benefits

### DIFF
--- a/benefits/README.md
+++ b/benefits/README.md
@@ -58,6 +58,103 @@ import { Benefits } from "@wingspan/benefits";
 
 <!-- End Dev Containers -->
 
+
+
+<!-- Start Error Handling -->
+# Error Handling
+
+Handling errors in your SDK should largely match your expectations.  All operations return a response object or throw an error.  If Error objects are specified in your OpenAPI Spec, the SDK will throw the appropriate Error type.
+
+
+<!-- End Error Handling -->
+
+
+
+<!-- Start Server Selection -->
+# Server Selection
+
+## Select Server by Index
+
+You can override the default server globally by passing a server index to the `serverIdx: number` optional parameter when initializing the SDK client instance. The selected server will then be used as the default on the operations that use it. This table lists the indexes associated with the available servers:
+
+| # | Server | Variables |
+| - | ------ | --------- |
+| 0 | `https://api.wingspan.app/benefits` | None |
+| 1 | `https://stagingapi.wingspan.app/benefits` | None |
+
+For example:
+
+
+```typescript
+import { Benefits } from "@wingspan/benefits";
+
+(async () => {
+    const sdk = new Benefits({
+        serverIdx: 1,
+    });
+
+    const res = await sdk.benefits.getBenefitsEnrollmentId({
+        id: "<ID>",
+    });
+
+    if (res.statusCode == 200) {
+        // handle response
+    }
+})();
+
+```
+
+
+## Override Server URL Per-Client
+
+The default server can also be overridden globally by passing a URL to the `serverURL: str` optional parameter when initializing the SDK client instance. For example:
+
+
+```typescript
+import { Benefits } from "@wingspan/benefits";
+
+(async () => {
+    const sdk = new Benefits({
+        serverURL: "https://api.wingspan.app/benefits",
+    });
+
+    const res = await sdk.benefits.getBenefitsEnrollmentId({
+        id: "<ID>",
+    });
+
+    if (res.statusCode == 200) {
+        // handle response
+    }
+})();
+
+```
+<!-- End Server Selection -->
+
+
+
+<!-- Start Custom HTTP Client -->
+# Custom HTTP Client
+
+The Typescript SDK makes API calls using the (axios)[https://axios-http.com/docs/intro] HTTP library.  In order to provide a convenient way to configure timeouts, cookies, proxies, custom headers, and other low-level configuration, you can initialize the SDK client with a custom `AxiosInstance` object.
+
+
+For example, you could specify a header for every request that your sdk makes as follows:
+
+```typescript
+from @wingspan/benefits import Benefits;
+import axios;
+
+const httpClient = axios.create({
+    headers: {'x-custom-header': 'someValue'}
+})
+
+
+const sdk = new Benefits({defaultClient: httpClient});
+```
+
+
+<!-- End Custom HTTP Client -->
+
 <!-- Placeholder for Future Speakeasy SDK Sections -->
 
 # Development

--- a/benefits/RELEASES.md
+++ b/benefits/RELEASES.md
@@ -69,3 +69,13 @@ Based on:
 - [typescript v1.6.0] benefits
 ### Releases
 - [NPM v1.6.0] https://www.npmjs.com/package/@wingspan/benefits/v/1.6.0 - benefits
+
+## 2023-10-31 13:46:02
+### Changes
+Based on:
+- OpenAPI Doc 1.0.0 https://docs.wingspan.app/openapi/6470f38d65c260000c025474
+- Speakeasy CLI 1.109.0 (2.173.0) https://github.com/speakeasy-api/speakeasy
+### Generated
+- [typescript v1.7.0] benefits
+### Releases
+- [NPM v1.7.0] https://www.npmjs.com/package/@wingspan/benefits/v/1.7.0 - benefits

--- a/benefits/RELEASES.md
+++ b/benefits/RELEASES.md
@@ -1,81 +1,10 @@
 
-
-## 2023-10-17 21:37:18
-### Changes
-Based on:
-- OpenAPI Doc 1.0.0 https://docs.wingspan.app/openapi/6470f38d65c260000c025474
-- Speakeasy CLI 1.101.0 (2.161.0) https://github.com/speakeasy-api/speakeasy
-### Generated
-- [typescript v2.0.0] benefits
-### Releases
-- [NPM v2.0.0] https://www.npmjs.com/package/@wingspanHQ/benefits/v/2.0.0 - benefits
-
-## 2023-10-18 14:22:23
-### Changes
-Based on:
-- OpenAPI Doc 1.0.0 https://docs.wingspan.app/openapi/6470f38d65c260000c025474
-- Speakeasy CLI 1.101.0 (2.161.0) https://github.com/speakeasy-api/speakeasy
-### Generated
-- [typescript v1.1.0] benefits
-### Releases
-- [NPM v1.1.0] https://www.npmjs.com/package/@wingspanHQ/benefits/v/1.1.0 - benefits
-
-## 2023-10-18 14:28:24
-### Changes
-Based on:
-- OpenAPI Doc 1.0.0 https://docs.wingspan.app/openapi/6470f38d65c260000c025474
-- Speakeasy CLI 1.101.0 (2.161.0) https://github.com/speakeasy-api/speakeasy
-### Generated
-- [typescript v1.2.0] benefits
-### Releases
-- [NPM v1.2.0] https://www.npmjs.com/package/@wingspanhq/benefits/v/1.2.0 - benefits
-
-## 2023-10-18 17:13:57
-### Changes
-Based on:
-- OpenAPI Doc 1.0.0 https://docs.wingspan.app/openapi/6470f38d65c260000c025474
-- Speakeasy CLI 1.101.0 (2.161.0) https://github.com/speakeasy-api/speakeasy
-### Generated
-- [typescript v1.3.0] benefits
-### Releases
-- [NPM v1.3.0] https://www.npmjs.com/package/@wingspanhq/benefits/v/1.3.0 - benefits
-
-## 2023-10-18 17:40:31
-### Changes
-Based on:
-- OpenAPI Doc 1.0.0 https://docs.wingspan.app/openapi/6470f38d65c260000c025474
-- Speakeasy CLI 1.101.0 (2.161.0) https://github.com/speakeasy-api/speakeasy
-### Generated
-- [typescript v1.4.0] benefits
-### Releases
-- [NPM v1.4.0] https://www.npmjs.com/package/@wingspan/benefits/v/1.4.0 - benefits
-
-## 2023-10-20 15:27:33
-### Changes
-Based on:
-- OpenAPI Doc 1.0.0 https://docs.wingspan.app/openapi/6470f38d65c260000c025474
-- Speakeasy CLI 1.102.0 (2.166.0) https://github.com/speakeasy-api/speakeasy
-### Generated
-- [typescript v1.5.0] benefits
-### Releases
-- [NPM v1.5.0] https://www.npmjs.com/package/@wingspan/benefits/v/1.5.0 - benefits
-
-## 2023-10-20 20:12:46
-### Changes
-Based on:
-- OpenAPI Doc 1.0.0 https://docs.wingspan.app/openapi/6470f38d65c260000c025474
-- Speakeasy CLI 1.102.1 (2.166.0) https://github.com/speakeasy-api/speakeasy
-### Generated
-- [typescript v1.6.0] benefits
-### Releases
-- [NPM v1.6.0] https://www.npmjs.com/package/@wingspan/benefits/v/1.6.0 - benefits
-
 ## 2023-10-31 13:46:02
 ### Changes
 Based on:
 - OpenAPI Doc 1.0.0 https://docs.wingspan.app/openapi/6470f38d65c260000c025474
 - Speakeasy CLI 1.109.0 (2.173.0) https://github.com/speakeasy-api/speakeasy
 ### Generated
-- [typescript v1.7.0] benefits
+- [typescript v1.0.0] benefits
 ### Releases
-- [NPM v1.7.0] https://www.npmjs.com/package/@wingspan/benefits/v/1.7.0 - benefits
+- [NPM v1.0.0] https://www.npmjs.com/package/@wingspan/benefits/v/1.0.0 - benefits

--- a/benefits/docs/sdks/benefits/README.md
+++ b/benefits/docs/sdks/benefits/README.md
@@ -29,6 +29,7 @@ import { Benefits } from "@wingspan/benefits";
     id: "<ID>",
   });
 
+
   if (res.statusCode == 200) {
     // handle response
   }
@@ -61,6 +62,7 @@ import { Benefits } from "@wingspan/benefits";
   const sdk = new Benefits();
 
   const res = await sdk.benefits.getBenefitsPlanEnrollment();
+
 
   if (res.statusCode == 200) {
     // handle response
@@ -96,6 +98,7 @@ import { Benefits } from "@wingspan/benefits";
     id: "<ID>",
   });
 
+
   if (res.statusCode == 200) {
     // handle response
   }
@@ -128,6 +131,7 @@ import { Benefits } from "@wingspan/benefits";
   const sdk = new Benefits();
 
   const res = await sdk.benefits.getBenefitsService();
+
 
   if (res.statusCode == 200) {
     // handle response
@@ -165,6 +169,7 @@ import { Benefits } from "@wingspan/benefits";
     },
     id: "<ID>",
   });
+
 
   if (res.statusCode == 200) {
     // handle response

--- a/benefits/gen.yaml
+++ b/benefits/gen.yaml
@@ -14,7 +14,7 @@ features:
     core: 2.94.0
     globalServerURLs: 2.82.0
 typescript:
-  version: 1.7.0
+  version: 1.0.0
   author: Wingspan Networks, Inc.
   flattenGlobalSecurity: true
   installationURL: https://gitpkg.now.sh/wingspanHQ/client-sdk-typescript/benefits

--- a/benefits/gen.yaml
+++ b/benefits/gen.yaml
@@ -2,8 +2,8 @@ configVersion: 1.0.0
 management:
   docChecksum: e377727f5ba4f1205fcadb3246757bab
   docVersion: 1.0.0
-  speakeasyVersion: 1.102.1
-  generationVersion: 2.166.0
+  speakeasyVersion: 1.109.0
+  generationVersion: 2.173.0
 generation:
   repoURL: https://github.com/wingspanHQ/client-sdk-typescript.git
   sdkClassName: benefits
@@ -11,10 +11,10 @@ generation:
   telemetryEnabled: false
 features:
   typescript:
-    core: 2.92.4
+    core: 2.94.0
     globalServerURLs: 2.82.0
 typescript:
-  version: 1.6.0
+  version: 1.7.0
   author: Wingspan Networks, Inc.
   flattenGlobalSecurity: true
   installationURL: https://gitpkg.now.sh/wingspanHQ/client-sdk-typescript/benefits

--- a/benefits/package-lock.json
+++ b/benefits/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wingspan/benefits",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wingspan/benefits",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "dependencies": {
         "axios": "^1.1.3",
         "class-transformer": "^0.5.1",

--- a/benefits/package.json
+++ b/benefits/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingspan/benefits",
-  "version": "1.7.0",
+  "version": "1.0.0",
   "author": "Wingspan Networks, Inc.",
   "scripts": {
     "prepare": "tsc --build",

--- a/benefits/package.json
+++ b/benefits/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingspan/benefits",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "author": "Wingspan Networks, Inc.",
   "scripts": {
     "prepare": "tsc --build",

--- a/benefits/src/internal/utils/security.ts
+++ b/benefits/src/internal/utils/security.ts
@@ -179,7 +179,7 @@ function parseSecuritySchemeValue(
       properties.headers[securityDecorator.Name] = value;
       break;
     case "oauth2":
-      properties.headers[securityDecorator.Name] = value;
+      properties.headers[securityDecorator.Name] = value.toLowerCase().startsWith("bearer ") ? value : `Bearer ${value}`;
       break;
     case "http":
       switch (schemeDecorator.SubType) {

--- a/benefits/src/sdk/sdk.ts
+++ b/benefits/src/sdk/sdk.ts
@@ -53,9 +53,9 @@ export class SDKConfiguration {
     serverDefaults: any;
     language = "typescript";
     openapiDocVersion = "1.0.0";
-    sdkVersion = "1.7.0";
+    sdkVersion = "1.0.0";
     genVersion = "2.173.0";
-    userAgent = "speakeasy-sdk/typescript 1.7.0 2.173.0 1.0.0 @wingspan/benefits";
+    userAgent = "speakeasy-sdk/typescript 1.0.0 2.173.0 1.0.0 @wingspan/benefits";
     retryConfig?: utils.RetryConfig;
     public constructor(init?: Partial<SDKConfiguration>) {
         Object.assign(this, init);

--- a/benefits/src/sdk/sdk.ts
+++ b/benefits/src/sdk/sdk.ts
@@ -53,9 +53,9 @@ export class SDKConfiguration {
     serverDefaults: any;
     language = "typescript";
     openapiDocVersion = "1.0.0";
-    sdkVersion = "1.6.0";
-    genVersion = "2.166.0";
-    userAgent = "speakeasy-sdk/typescript 1.6.0 2.166.0 1.0.0 @wingspan/benefits";
+    sdkVersion = "1.7.0";
+    genVersion = "2.173.0";
+    userAgent = "speakeasy-sdk/typescript 1.7.0 2.173.0 1.0.0 @wingspan/benefits";
     retryConfig?: utils.RetryConfig;
     public constructor(init?: Partial<SDKConfiguration>) {
         Object.assign(this, init);


### PR DESCRIPTION
# Generated by Speakeasy CLI
Based on:
- OpenAPI Doc 1.0.0 https://docs.wingspan.app/openapi/6470f38d65c260000c025474
- Speakeasy CLI 1.109.0 (2.173.0) https://github.com/speakeasy-api/speakeasy


## TYPESCRIPT CHANGELOG

## core: 2.94.0 - 2023-10-24
### :bee: New Features
- oauth defaults to bearer usage *(commit by [@ryan-timothy-albert](https://github.com/ryan-timothy-albert))*



## core: 2.93.0 - 2023-10-20
### :bee: New Features
- add local iteration instructions to new READMEs *(commit by [@chase-crumbaugh](https://github.com/chase-crumbaugh))*


