### PR TITLE
chore: speakeasy sdk regeneration - Generate Client SDKs for Wingspan files

### DIFF
--- a/files/README.md
+++ b/files/README.md
@@ -76,6 +76,103 @@ import { Files } from "@wingspan/files";
 
 <!-- End Dev Containers -->
 
+
+
+<!-- Start Error Handling -->
+# Error Handling
+
+Handling errors in your SDK should largely match your expectations.  All operations return a response object or throw an error.  If Error objects are specified in your OpenAPI Spec, the SDK will throw the appropriate Error type.
+
+
+<!-- End Error Handling -->
+
+
+
+<!-- Start Server Selection -->
+# Server Selection
+
+## Select Server by Index
+
+You can override the default server globally by passing a server index to the `serverIdx: number` optional parameter when initializing the SDK client instance. The selected server will then be used as the default on the operations that use it. This table lists the indexes associated with the available servers:
+
+| # | Server | Variables |
+| - | ------ | --------- |
+| 0 | `https://api.wingspan.app/files` | None |
+| 1 | `https://stagingapi.wingspan.app/files` | None |
+
+For example:
+
+
+```typescript
+import { Files } from "@wingspan/files";
+
+(async () => {
+    const sdk = new Files({
+        serverIdx: 1,
+    });
+
+    const res = await sdk.files.deleteFilesMemberPrivateId({
+        id: "<ID>",
+    });
+
+    if (res.statusCode == 200) {
+        // handle response
+    }
+})();
+
+```
+
+
+## Override Server URL Per-Client
+
+The default server can also be overridden globally by passing a URL to the `serverURL: str` optional parameter when initializing the SDK client instance. For example:
+
+
+```typescript
+import { Files } from "@wingspan/files";
+
+(async () => {
+    const sdk = new Files({
+        serverURL: "https://api.wingspan.app/files",
+    });
+
+    const res = await sdk.files.deleteFilesMemberPrivateId({
+        id: "<ID>",
+    });
+
+    if (res.statusCode == 200) {
+        // handle response
+    }
+})();
+
+```
+<!-- End Server Selection -->
+
+
+
+<!-- Start Custom HTTP Client -->
+# Custom HTTP Client
+
+The Typescript SDK makes API calls using the (axios)[https://axios-http.com/docs/intro] HTTP library.  In order to provide a convenient way to configure timeouts, cookies, proxies, custom headers, and other low-level configuration, you can initialize the SDK client with a custom `AxiosInstance` object.
+
+
+For example, you could specify a header for every request that your sdk makes as follows:
+
+```typescript
+from @wingspan/files import Files;
+import axios;
+
+const httpClient = axios.create({
+    headers: {'x-custom-header': 'someValue'}
+})
+
+
+const sdk = new Files({defaultClient: httpClient});
+```
+
+
+<!-- End Custom HTTP Client -->
+
 <!-- Placeholder for Future Speakeasy SDK Sections -->
 
 # Development

--- a/files/RELEASES.md
+++ b/files/RELEASES.md
@@ -1,31 +1,10 @@
 
-
-## 2023-10-20 15:28:08
-### Changes
-Based on:
-- OpenAPI Doc 1.0.0 https://docs.wingspan.app/openapi/6470f51b81948601a18934c5
-- Speakeasy CLI 1.102.0 (2.166.0) https://github.com/speakeasy-api/speakeasy
-### Generated
-- [typescript v2.0.0] files
-### Releases
-- [NPM v2.0.0] https://www.npmjs.com/package/@wingspan/files/v/2.0.0 - files
-
-## 2023-10-20 20:19:40
-### Changes
-Based on:
-- OpenAPI Doc 1.0.0 https://docs.wingspan.app/openapi/6470f51b81948601a18934c5
-- Speakeasy CLI 1.102.1 (2.166.0) https://github.com/speakeasy-api/speakeasy
-### Generated
-- [typescript v2.1.0] files
-### Releases
-- [NPM v2.1.0] https://www.npmjs.com/package/@wingspan/files/v/2.1.0 - files
-
 ## 2023-10-31 13:47:25
 ### Changes
 Based on:
 - OpenAPI Doc 1.0.0 https://docs.wingspan.app/openapi/6470f51b81948601a18934c5
 - Speakeasy CLI 1.109.0 (2.173.0) https://github.com/speakeasy-api/speakeasy
 ### Generated
-- [typescript v1.2.0] files
+- [typescript v1.0.0] files
 ### Releases
-- [NPM v1.2.0] https://www.npmjs.com/package/@wingspan/files/v/1.2.0 - files
+- [NPM v1.0.0] https://www.npmjs.com/package/@wingspan/files/v/1.0.0 - files

--- a/files/RELEASES.md
+++ b/files/RELEASES.md
@@ -19,3 +19,13 @@ Based on:
 - [typescript v2.1.0] files
 ### Releases
 - [NPM v2.1.0] https://www.npmjs.com/package/@wingspan/files/v/2.1.0 - files
+
+## 2023-10-31 13:47:25
+### Changes
+Based on:
+- OpenAPI Doc 1.0.0 https://docs.wingspan.app/openapi/6470f51b81948601a18934c5
+- Speakeasy CLI 1.109.0 (2.173.0) https://github.com/speakeasy-api/speakeasy
+### Generated
+- [typescript v1.2.0] files
+### Releases
+- [NPM v1.2.0] https://www.npmjs.com/package/@wingspan/files/v/1.2.0 - files

--- a/files/docs/models/shared/documentevents.md
+++ b/files/docs/models/shared/documentevents.md
@@ -6,5 +6,4 @@
 | Field              | Type               | Required           | Description        |
 | ------------------ | ------------------ | ------------------ | ------------------ |
 | `clientSignedAt`   | *string*           | :heavy_minus_sign: | N/A                |
-| `completedAt`      | *string*           | :heavy_minus_sign: | N/A                |
 | `memberSignedAt`   | *string*           | :heavy_minus_sign: | N/A                |

--- a/files/docs/sdks/files/README.md
+++ b/files/docs/sdks/files/README.md
@@ -47,6 +47,7 @@ import { Files } from "@wingspan/files";
     id: "<ID>",
   });
 
+
   if (res.statusCode == 200) {
     // handle response
   }
@@ -81,6 +82,7 @@ import { Files } from "@wingspan/files";
   const res = await sdk.files.deleteFilesMemberPublicId({
     id: "<ID>",
   });
+
 
   if (res.statusCode == 200) {
     // handle response
@@ -117,6 +119,7 @@ import { Files } from "@wingspan/files";
     id: "<ID>",
   });
 
+
   if (res.statusCode == 200) {
     // handle response
   }
@@ -149,6 +152,7 @@ import { Files } from "@wingspan/files";
   const sdk = new Files();
 
   const res = await sdk.files.getFilesDocument();
+
 
   if (res.statusCode == 200) {
     // handle response
@@ -183,6 +187,7 @@ import { Files } from "@wingspan/files";
   const res = await sdk.files.getFilesDocumentId({
     id: "<ID>",
   });
+
 
   if (res.statusCode == 200) {
     // handle response
@@ -219,6 +224,7 @@ import { Files } from "@wingspan/files";
     id: "<ID>",
   });
 
+
   if (res.statusCode == 200) {
     // handle response
   }
@@ -254,6 +260,7 @@ import { Files } from "@wingspan/files";
     id: "<ID>",
   });
 
+
   if (res.statusCode == 200) {
     // handle response
   }
@@ -286,6 +293,7 @@ import { Files } from "@wingspan/files";
   const sdk = new Files();
 
   const res = await sdk.files.getFilesMemberPrivate();
+
 
   if (res.statusCode == 200) {
     // handle response
@@ -320,6 +328,7 @@ import { Files } from "@wingspan/files";
   const res = await sdk.files.getFilesMemberPrivateId({
     id: "<ID>",
   });
+
 
   if (res.statusCode == 200) {
     // handle response
@@ -356,6 +365,7 @@ import { Files } from "@wingspan/files";
     id: "<ID>",
   });
 
+
   if (res.statusCode == 200) {
     // handle response
   }
@@ -388,6 +398,7 @@ import { Files } from "@wingspan/files";
   const sdk = new Files();
 
   const res = await sdk.files.getFilesMemberPublic();
+
 
   if (res.statusCode == 200) {
     // handle response
@@ -422,6 +433,7 @@ import { Files } from "@wingspan/files";
   const res = await sdk.files.getFilesMemberPublicId({
     id: "<ID>",
   });
+
 
   if (res.statusCode == 200) {
     // handle response
@@ -458,6 +470,7 @@ import { Files } from "@wingspan/files";
     id: "<ID>",
   });
 
+
   if (res.statusCode == 200) {
     // handle response
   }
@@ -493,6 +506,7 @@ import { Files } from "@wingspan/files";
     id: "<ID>",
   });
 
+
   if (res.statusCode == 200) {
     // handle response
   }
@@ -525,6 +539,7 @@ import { Files } from "@wingspan/files";
   const sdk = new Files();
 
   const res = await sdk.files.getFilesTemplate();
+
 
   if (res.statusCode == 200) {
     // handle response
@@ -559,6 +574,7 @@ import { Files } from "@wingspan/files";
   const res = await sdk.files.getFilesTemplateId({
     id: "<ID>",
   });
+
 
   if (res.statusCode == 200) {
     // handle response
@@ -598,6 +614,7 @@ import { Files } from "@wingspan/files";
     id: "<ID>",
   });
 
+
   if (res.statusCode == 200) {
     // handle response
   }
@@ -636,6 +653,7 @@ import { Files } from "@wingspan/files";
     id: "<ID>",
   });
 
+
   if (res.statusCode == 200) {
     // handle response
   }
@@ -669,6 +687,7 @@ import { Files } from "@wingspan/files";
 
   const res = await sdk.files.postFilesMemberPrivate();
 
+
   if (res.statusCode == 200) {
     // handle response
   }
@@ -700,6 +719,7 @@ import { Files } from "@wingspan/files";
   const sdk = new Files();
 
   const res = await sdk.files.postFilesMemberPrivateUpload();
+
 
   if (res.statusCode == 200) {
     // handle response
@@ -733,6 +753,7 @@ import { Files } from "@wingspan/files";
 
   const res = await sdk.files.postFilesMemberPublic();
 
+
   if (res.statusCode == 200) {
     // handle response
   }
@@ -764,6 +785,7 @@ import { Files } from "@wingspan/files";
   const sdk = new Files();
 
   const res = await sdk.files.postFilesMemberPublicUpload();
+
 
   if (res.statusCode == 200) {
     // handle response
@@ -797,13 +819,14 @@ import { TemplateCreateRequestPurpose, TemplateCreateRequestRoles } from "@wings
   const sdk = new Files();
 
   const res = await sdk.files.postFilesTemplate({
-    fileId: "chase",
+    fileId: "string",
     purpose: TemplateCreateRequestPurpose.OnboardCollaborator,
     roles: [
-      TemplateCreateRequestRoles.Client,
+      TemplateCreateRequestRoles.LessThanNilGreaterThan,
     ],
-    title: "Midland",
+    title: "string",
   });
+
 
   if (res.statusCode == 200) {
     // handle response

--- a/files/gen.yaml
+++ b/files/gen.yaml
@@ -1,9 +1,9 @@
 configVersion: 1.0.0
 management:
-  docChecksum: 7b9ba3dec08439d2014e6f704737f859
+  docChecksum: 506ffafb9dea0d48efd230befc2c3108
   docVersion: 1.0.0
-  speakeasyVersion: 1.102.1
-  generationVersion: 2.166.0
+  speakeasyVersion: 1.109.0
+  generationVersion: 2.173.0
 generation:
   repoURL: https://github.com/wingspanHQ/client-sdk-typescript.git
   sdkClassName: files
@@ -11,10 +11,10 @@ generation:
   telemetryEnabled: false
 features:
   typescript:
-    core: 2.92.4
+    core: 2.94.0
     globalServerURLs: 2.82.0
 typescript:
-  version: 1.1.0
+  version: 1.2.0
   author: Wingspan Networks, Inc.
   flattenGlobalSecurity: true
   installationURL: https://gitpkg.now.sh/wingspanHQ/client-sdk-typescript/files

--- a/files/gen.yaml
+++ b/files/gen.yaml
@@ -14,7 +14,7 @@ features:
     core: 2.94.0
     globalServerURLs: 2.82.0
 typescript:
-  version: 1.2.0
+  version: 1.0.0
   author: Wingspan Networks, Inc.
   flattenGlobalSecurity: true
   installationURL: https://gitpkg.now.sh/wingspanHQ/client-sdk-typescript/files

--- a/files/package-lock.json
+++ b/files/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wingspan/files",
-  "version": "2.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wingspan/files",
-      "version": "2.1.0",
+      "version": "1.2.0",
       "dependencies": {
         "axios": "^1.1.3",
         "class-transformer": "^0.5.1",

--- a/files/package.json
+++ b/files/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingspan/files",
-  "version": "1.2.0",
+  "version": "1.0.0",
   "author": "Wingspan Networks, Inc.",
   "scripts": {
     "prepare": "tsc --build",

--- a/files/package.json
+++ b/files/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingspan/files",
-  "version": "2.1.0",
+  "version": "1.2.0",
   "author": "Wingspan Networks, Inc.",
   "scripts": {
     "prepare": "tsc --build",

--- a/files/src/internal/utils/security.ts
+++ b/files/src/internal/utils/security.ts
@@ -179,7 +179,7 @@ function parseSecuritySchemeValue(
       properties.headers[securityDecorator.Name] = value;
       break;
     case "oauth2":
-      properties.headers[securityDecorator.Name] = value;
+      properties.headers[securityDecorator.Name] = value.toLowerCase().startsWith("bearer ") ? value : `Bearer ${value}`;
       break;
     case "http":
       switch (schemeDecorator.SubType) {

--- a/files/src/sdk/models/shared/documentevents.ts
+++ b/files/src/sdk/models/shared/documentevents.ts
@@ -11,10 +11,6 @@ export class DocumentEvents extends SpeakeasyBase {
     clientSignedAt?: string;
 
     @SpeakeasyMetadata()
-    @Expose({ name: "completedAt" })
-    completedAt?: string;
-
-    @SpeakeasyMetadata()
     @Expose({ name: "memberSignedAt" })
     memberSignedAt?: string;
 }

--- a/files/src/sdk/sdk.ts
+++ b/files/src/sdk/sdk.ts
@@ -53,9 +53,9 @@ export class SDKConfiguration {
     serverDefaults: any;
     language = "typescript";
     openapiDocVersion = "1.0.0";
-    sdkVersion = "2.1.0";
-    genVersion = "2.166.0";
-    userAgent = "speakeasy-sdk/typescript 2.1.0 2.166.0 1.0.0 @wingspan/files";
+    sdkVersion = "1.2.0";
+    genVersion = "2.173.0";
+    userAgent = "speakeasy-sdk/typescript 1.2.0 2.173.0 1.0.0 @wingspan/files";
     retryConfig?: utils.RetryConfig;
     public constructor(init?: Partial<SDKConfiguration>) {
         Object.assign(this, init);

--- a/files/src/sdk/sdk.ts
+++ b/files/src/sdk/sdk.ts
@@ -53,9 +53,9 @@ export class SDKConfiguration {
     serverDefaults: any;
     language = "typescript";
     openapiDocVersion = "1.0.0";
-    sdkVersion = "1.2.0";
+    sdkVersion = "1.0.0";
     genVersion = "2.173.0";
-    userAgent = "speakeasy-sdk/typescript 1.2.0 2.173.0 1.0.0 @wingspan/files";
+    userAgent = "speakeasy-sdk/typescript 1.0.0 2.173.0 1.0.0 @wingspan/files";
     retryConfig?: utils.RetryConfig;
     public constructor(init?: Partial<SDKConfiguration>) {
         Object.assign(this, init);


### PR DESCRIPTION
# Generated by Speakeasy CLI
Based on:
- OpenAPI Doc 1.0.0 https://docs.wingspan.app/openapi/6470f51b81948601a18934c5
- Speakeasy CLI 1.109.0 (2.173.0) https://github.com/speakeasy-api/speakeasy


## TYPESCRIPT CHANGELOG

## core: 2.94.0 - 2023-10-24
### :bee: New Features
- oauth defaults to bearer usage *(commit by [@ryan-timothy-albert](https://github.com/ryan-timothy-albert))*



## core: 2.93.0 - 2023-10-20
### :bee: New Features
- add local iteration instructions to new READMEs *(commit by [@chase-crumbaugh](https://github.com/chase-crumbaugh))*


